### PR TITLE
Adds mechanism for contexts

### DIFF
--- a/cleverdiff/__main__.py
+++ b/cleverdiff/__main__.py
@@ -1,4 +1,4 @@
 from .cleverdiff import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/cleverdiff/cleverdiff.py
+++ b/cleverdiff/cleverdiff.py
@@ -4,18 +4,9 @@ import sys
 import collections
 
 from .difflist import DiffList
+from .contexts import EcflowContext
 
 DiffRecord = collections.namedtuple("DiffRecord", "diffitem controlindex diffmode")
-
-
-def contexts(diffitem):
-    msg = "{} (line {}) to {} (line {})"
-    return msg.format(
-        diffitem.contexts.first,
-        diffitem.lines.first,
-        diffitem.contexts.second,
-        diffitem.lines.second,
-    )
 
 
 def summarise_results(diffseen, diffresult):

--- a/cleverdiff/cleverdiff.py
+++ b/cleverdiff/cleverdiff.py
@@ -1,18 +1,21 @@
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
 
 import sys
 import collections
 
 from .difflist import DiffList
 
-DiffRecord = collections.namedtuple('DiffRecord',
-                                    'diffitem controlindex diffmode')
+DiffRecord = collections.namedtuple("DiffRecord", "diffitem controlindex diffmode")
 
 
 def contexts(diffitem):
     msg = "{} (line {}) to {} (line {})"
-    return msg.format(diffitem.contexts.first, diffitem.lines.first,
-                      diffitem.contexts.second, diffitem.lines.second)
+    return msg.format(
+        diffitem.contexts.first,
+        diffitem.lines.first,
+        diffitem.contexts.second,
+        diffitem.lines.second,
+    )
 
 
 def summarise_results(diffseen, diffresult):
@@ -40,10 +43,9 @@ def summarise_results(diffseen, diffresult):
     }
 
     result = ""
-    for seenindex, seenitem, in enumerate(diffseen):
+    for seenindex, seenitem in enumerate(diffseen):
         result += "--------------------------------------------\n"
-        result += (f"DIFF {seenindex:3d}:\n"
-                   f"{str(seenitem)}")
+        result += f"DIFF {seenindex:3d}:\n" f"{str(seenitem)}"
         result2 = {key: [] for key in MODE_DESCRIPTION.keys()}
         for hunk2, controlindex, mode in diffresult:
             if controlindex != seenindex:
@@ -78,15 +80,13 @@ def main(infilepairs=None):
         for diffitem in difflist.diffs:
             found = False
             if len(diffseen) > 0:
-                for seenindex, seenitem, in enumerate(diffseen):
+                for seenindex, seenitem in enumerate(diffseen):
                     cmp = diffitem.compare(seenitem)
                     if cmp < 2:
                         found = True
                         diffresult.append(
                             DiffRecord(
-                                diffitem=diffitem,
-                                controlindex=seenindex,
-                                diffmode=cmp,
+                                diffitem=diffitem, controlindex=seenindex, diffmode=cmp
                             )
                         )
                         break
@@ -95,5 +95,3 @@ def main(infilepairs=None):
                 diffseen.append(diffitem)
 
     print(summarise_results(diffseen, diffresult))
-
-

--- a/cleverdiff/cleverdiff.py
+++ b/cleverdiff/cleverdiff.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function  # noqa
 
 import sys
+import os.path
 import collections
 
 from .difflist import DiffList
-from .contexts import EcflowContext
+from .contexts import DefaultContext, lookup_extension
 
 DiffRecord = collections.namedtuple("DiffRecord", "diffitem controlindex diffmode")
 
@@ -58,16 +59,12 @@ def summarise_results(diffseen, diffresult):
     return result
 
 
-def main(infilepairs=None):
-    if infilepairs is None:
-        infilepairs = sys.argv[1:]
-
+def main_diff(filepairs, context_cls=None):
     diffseen = []
     diffresult = []
-    filepairs = [item.split("=") for item in infilepairs]
 
     for lhs, rhs in filepairs:
-        difflist = DiffList.from_files(lhs, rhs)
+        difflist = DiffList.from_files(lhs, rhs, context_cls)
         for diffitem in difflist.diffs:
             found = False
             if len(diffseen) > 0:
@@ -86,3 +83,21 @@ def main(infilepairs=None):
                 diffseen.append(diffitem)
 
     print(summarise_results(diffseen, diffresult))
+
+
+def main(in_file_pairs=None):
+    if in_file_pairs is None:
+        in_file_pairs = sys.argv[1:]
+    file_pairs = [item.split("=") for item in in_file_pairs]
+
+    if not in_file_pairs:
+        raise ValueError("insufficient arguments")
+
+    exts = [os.path.splitext(f)[-1] for file_pair in file_pairs for f in file_pair]
+    if len(set(exts)) > 1:
+        context_cls = DefaultContext
+    else:
+        context_cls = lookup_extension(exts[0])
+
+    print(f"detected {context_cls.DESCRIPTION}")
+    main_diff(file_pairs, context_cls=context_cls)

--- a/cleverdiff/contexts.py
+++ b/cleverdiff/contexts.py
@@ -1,0 +1,18 @@
+class DefaultContext:
+    def __init__(self, label):
+        self.label = label
+
+    def __getitem__(self, item):
+        return self.label
+
+
+class EcflowContext:
+    def __init__(self, label):
+        self.label = label
+        self._context = self._parse(label)
+
+    def _parse(self, filename):
+        pass
+
+    def __getitem__(self, item):
+        return self._context[item]

--- a/cleverdiff/contexts.py
+++ b/cleverdiff/contexts.py
@@ -12,11 +12,11 @@ class DefaultContext:
     DESCRIPTION = "unformatted text file"
 
     def __init__(self, filename):
-        self.filename = filename
+        self._filename = filename
 
-    def __getitem__(self, line):
+    def __getitem__(self, line_number):
         """Returns the filename and given line number as a string."""
-        return f"{self.filename}:{line}"
+        return f"{self._filename}:{line_number}"
 
 
 class EcflowContext:
@@ -28,8 +28,8 @@ class EcflowContext:
     DESCRIPTION = "ecFlow suite definition"
 
     def __init__(self, filename):
-        self.filename = filename
-        with open(filename, "rt") as f:
+        self._filename = filename
+        with open(self._filename, "rt") as f:
             self._context = self._create_context(f.read().splitlines())
 
     @classmethod
@@ -72,8 +72,9 @@ class EcflowContext:
 
         return result
 
-    def __getitem__(self, item):
-        return f"{self.filename}:{self._context[item]}"
+    def __getitem__(self, line_number):
+        """Return the filename and path of the current node at the given line number."""
+        return f"{self._filename}:{self._context[line_number]}"
 
 
 # A dict mapping filename extensions to context classes

--- a/cleverdiff/contexts.py
+++ b/cleverdiff/contexts.py
@@ -1,4 +1,6 @@
 class DefaultContext:
+    DESCRIPTION = "unformatted text file"
+
     def __init__(self, filename):
         self.label = filename
 
@@ -7,6 +9,8 @@ class DefaultContext:
 
 
 class EcflowContext:
+    DESCRIPTION = "ecFlow suite definition"
+
     def __init__(self, filename):
         self.label = filename
         with open(filename, "rt") as f:
@@ -52,3 +56,12 @@ class EcflowContext:
 
     def __getitem__(self, item):
         return f"{self.label}:{self._context[item]}"
+
+
+EXTENSION_MAPPING = {
+    ".def": EcflowContext,
+}
+
+
+def lookup_extension(extension):
+    return EXTENSION_MAPPING.get(extension, DefaultContext)

--- a/cleverdiff/contexts.py
+++ b/cleverdiff/contexts.py
@@ -1,18 +1,54 @@
 class DefaultContext:
-    def __init__(self, label):
-        self.label = label
+    def __init__(self, filename):
+        self.label = filename
 
     def __getitem__(self, item):
-        return self.label
+        return f"{self.label}:{item}"
 
 
 class EcflowContext:
-    def __init__(self, label):
-        self.label = label
-        self._context = self._parse(label)
+    def __init__(self, filename):
+        self.label = filename
+        with open(filename, "rt") as f:
+            self._context = self._create_context(f.read().splitlines())
 
-    def _parse(self, filename):
-        pass
+    @classmethod
+    def _create_context(cls, content):
+        """
+        Given string content, establish a human-readable context for each
+        line.
+
+        Arguments
+        ---------
+        content : list of str
+            The contents to parse, as a list of strings (one string per line).
+
+        Returns
+        -------
+        list
+            A list of strings describing each line of the content.
+        """
+        result = []
+        stack = [""]
+        last_kw = None
+        for line in content:
+            line = line.strip()
+            try:
+                keyword, value = line.split()
+            except ValueError:
+                keyword = line
+                value = ''
+            if keyword in ['endsuite', 'endfamily']:
+                stack.pop()
+            if keyword in ['suite', 'family', 'task']:
+                if last_kw == 'task':
+                    stack.pop()
+                last_kw = keyword
+                stack.append(value)
+
+            result.append('/'.join(stack))
+
+        return result
 
     def __getitem__(self, item):
-        return self._context[item]
+        return f"{self.label}:{self._context[item]}"

--- a/cleverdiff/contexts.py
+++ b/cleverdiff/contexts.py
@@ -1,18 +1,34 @@
+"""
+Defines classes for providing the context of different file types.
+See DefaultContext for the interface.
+
+The types in this module should be passed into the `difflist.DiffList` constructor
+to specify how to translate line numbers into human-readable strings.
+"""
+
+
 class DefaultContext:
+    """A generic context which just returns line numbers."""
     DESCRIPTION = "unformatted text file"
 
     def __init__(self, filename):
-        self.label = filename
+        self.filename = filename
 
-    def __getitem__(self, item):
-        return f"{self.label}:{item}"
+    def __getitem__(self, line):
+        """Returns the filename and given line number as a string."""
+        return f"{self.filename}:{line}"
 
 
 class EcflowContext:
+    """
+    A context class that understands ecFlow suite definitions. These are
+    documented at
+    https://confluence.ecmwf.int/display/ECFLOW/Definition+file+Grammar.
+    """
     DESCRIPTION = "ecFlow suite definition"
 
     def __init__(self, filename):
-        self.label = filename
+        self.filename = filename
         with open(filename, "rt") as f:
             self._context = self._create_context(f.read().splitlines())
 
@@ -20,7 +36,7 @@ class EcflowContext:
     def _create_context(cls, content):
         """
         Given string content, establish a human-readable context for each
-        line.
+        line. This will be the path of the current node at each line.
 
         Arguments
         ---------
@@ -31,7 +47,9 @@ class EcflowContext:
         -------
         list
             A list of strings describing each line of the content.
+
         """
+
         result = []
         stack = [""]
         last_kw = None
@@ -55,13 +73,31 @@ class EcflowContext:
         return result
 
     def __getitem__(self, item):
-        return f"{self.label}:{self._context[item]}"
+        return f"{self.filename}:{self._context[item]}"
 
 
+# A dict mapping filename extensions to context classes
 EXTENSION_MAPPING = {
     ".def": EcflowContext,
 }
 
 
 def lookup_extension(extension):
+    """
+    Returns a class type for a given filename extension. If the
+    requested extension does not have an associated class type,
+    returns `DefaultContext`.
+
+    Arguments
+    ---------
+
+    extension : str
+        The extension of the filename, including the leading dot.
+
+    Returns
+    -------
+    type
+        A class name representing the context.
+
+    """
     return EXTENSION_MAPPING.get(extension, DefaultContext)

--- a/cleverdiff/diffhunk.py
+++ b/cleverdiff/diffhunk.py
@@ -36,7 +36,7 @@ class DiffHunk(object):
     def context_to_string(self, no_labels=False):
         context1 = "" if no_labels else self.context.first
         context2 = "" if no_labels else self.context.second
-        return f"{context1}:{self.lines.first} vs {context2}:{self.lines.second}"
+        return f"{context1} vs {context2}"
 
     def __str__(self):
         return f"{self.mode} in {self.context_to_string()}:\n{self.content}\n"

--- a/cleverdiff/diffhunk.py
+++ b/cleverdiff/diffhunk.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
 
 import collections
 

--- a/cleverdiff/difflist.py
+++ b/cleverdiff/difflist.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
 
 import difflib
 
@@ -20,8 +20,7 @@ class DiffList(object):
         self._secondlabel = label2
 
         # Compute and parse differences.
-        self._diffs = self._parse(difflib.unified_diff(self._first,
-                                                       self._second, n=0))
+        self._diffs = self._parse(difflib.unified_diff(self._first, self._second, n=0))
 
     @classmethod
     def _translate_diff_syntax(cls, syntax):
@@ -42,6 +41,7 @@ class DiffList(object):
             and the two integers are the start line from each input.
         """
         import re
+
         pattern = re.compile(r"^@@ -(\d+)(,(\d*))? \+(\d+)(,(\d*))? @@$")
         result = pattern.match(syntax)
         try:
@@ -119,16 +119,19 @@ class DiffList(object):
         mode = ""
         line1 = line2 = 0
         for diff_line in input_lines:
-            if diff_line.startswith('---'):
+            if diff_line.startswith("---"):
                 continue
-            elif diff_line.startswith('+++'):
+            elif diff_line.startswith("+++"):
                 continue
             elif diff_line.startswith("@@"):
                 if mode:
                     lines = Pair(first=line1, second=line2)
-                    hunk_obj = DiffHunk(mode=mode, content=hunk_content,
-                                        context=Pair(first=self._firstlabel, second=self._secondlabel),
-                                        lines=lines)
+                    hunk_obj = DiffHunk(
+                        mode=mode,
+                        content=hunk_content,
+                        context=Pair(first=self._firstlabel, second=self._secondlabel),
+                        lines=lines,
+                    )
                     difflist.append(hunk_obj)
 
                 # next hunk...
@@ -137,9 +140,12 @@ class DiffList(object):
             else:
                 hunk_content += diff_line
 
-        hunk_obj = DiffHunk(mode=mode, content=hunk_content,
-                            context=Pair(first=self._firstlabel, second=self._secondlabel),
-                            lines=Pair(first=line1, second=line2))
+        hunk_obj = DiffHunk(
+            mode=mode,
+            content=hunk_content,
+            context=Pair(first=self._firstlabel, second=self._secondlabel),
+            lines=Pair(first=line1, second=line2),
+        )
         difflist.append(hunk_obj)
 
         return difflist

--- a/cleverdiff/difflist.py
+++ b/cleverdiff/difflist.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import, division, print_function  # noqa
 import difflib
 
 from cleverdiff.diffhunk import DiffHunk, Pair
+from cleverdiff.contexts import DefaultContext
 
 
 class DiffList(object):
     """A class to contain lists of differences between two strings."""
 
-    def __init__(self, string1, string2, label1="", label2=""):
+    def __init__(self, string1, string2, label1="", label2="", context_objects=None):
         """Initialise a DiffList object."""
 
         super(DiffList, self).__init__()
@@ -18,6 +19,13 @@ class DiffList(object):
         self._second = string2.splitlines(True)
         self._firstlabel = label1
         self._secondlabel = label2
+
+        # Initialise objects to manage context.
+        if context_objects is None:
+            self._firstcontext = DefaultContext(label1)
+            self._secondcontext = DefaultContext(label2)
+        else:
+            self._firstcontext, self._secondcontext = context_objects
 
         # Compute and parse differences.
         self._diffs = self._parse(difflib.unified_diff(self._first, self._second, n=0))
@@ -72,7 +80,7 @@ class DiffList(object):
         return mode, start1, start2
 
     @classmethod
-    def from_files(cls, file1, file2):
+    def from_files(cls, file1, file2, context_cls=None):
         """
         Construct a DiffList object from the differences between two
         files.
@@ -85,14 +93,23 @@ class DiffList(object):
         file2 : str
             The filename of the second file.
 
+        context_cls : type, optional
+            A class which will be instantiated for each of the filenames
+            above, and will provide the human-readable context of lines.
+            If not provided, defaults to DefaultContext.
+
         Returns
         -------
         DiffList
             An object representing the differences between the given files.
         """
+        if context_cls is None:
+            context_cls = DefaultContext
+
         try:
             with open(file1, "rt") as f1, open(file2, "rt") as f2:
-                return cls(f1.read(), f2.read(), label1=file1, label2=file2)
+                return cls(f1.read(), f2.read(), label1=file1, label2=file2,
+                           context_objects=[context_cls(file1), context_cls(file2)])
         except IOError as excinfo:
             msg = "failed to load from file {}: {}"
             raise IOError(msg.format(excinfo.filename, excinfo))
@@ -125,12 +142,11 @@ class DiffList(object):
                 continue
             elif diff_line.startswith("@@"):
                 if mode:
-                    lines = Pair(first=line1, second=line2)
                     hunk_obj = DiffHunk(
                         mode=mode,
                         content=hunk_content,
-                        context=Pair(first=self._firstlabel, second=self._secondlabel),
-                        lines=lines,
+                        context=Pair(first=self._firstcontext[line1], second=self._secondcontext[line2]),
+                        lines=Pair(first=line1, second=line2),
                     )
                     difflist.append(hunk_obj)
 
@@ -143,7 +159,7 @@ class DiffList(object):
         hunk_obj = DiffHunk(
             mode=mode,
             content=hunk_content,
-            context=Pair(first=self._firstlabel, second=self._secondlabel),
+            context=Pair(first=self._firstcontext[line1], second=self._secondcontext[line2]),
             lines=Pair(first=line1, second=line2),
         )
         difflist.append(hunk_obj)

--- a/cleverdiff/difflist.py
+++ b/cleverdiff/difflist.py
@@ -120,7 +120,7 @@ class DiffList(object):
 
         Arguments
         ---------
-        input_lines : list
+        input_lines : list of str
             A list of strings containing a sequence of differences to parse.
             Must be in GNU unified diff format, defined at:
             https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified

--- a/cleverdiff/difflist.py
+++ b/cleverdiff/difflist.py
@@ -82,7 +82,7 @@ class DiffList(object):
         file1 : str
             The filename of the first file.
         
-        file1 : str
+        file2 : str
             The filename of the second file.
 
         Returns

--- a/cleverdiff/test_contexts.py
+++ b/cleverdiff/test_contexts.py
@@ -1,0 +1,96 @@
+import tempfile
+import textwrap
+from mock import patch
+
+from cleverdiff.contexts import DefaultContext, EcflowContext
+
+
+class Test_DefaultContext:
+    def test_description(self):
+        """Ensure there is an appropriate DESCRIPTION attribute."""
+        assert hasattr(DefaultContext, "DESCRIPTION")
+
+        expected = "unformatted text file"
+        actual = DefaultContext.DESCRIPTION
+        assert expected == actual
+
+    def test_getindex(self):
+        """Ensure that dict notation returns a sensible string."""
+        filename = '/path/to/foobar'
+        instance = DefaultContext(filename)
+
+        actual = instance[3]
+        expected = f"{filename}:3"
+        assert expected == actual
+
+        actual = instance[256]
+        expected = f"{filename}:256"
+        assert expected == actual
+
+
+class Test_EcflowContext:
+    def test_description(self):
+        """Ensure there is an appropriate DESCRIPTION attribute."""
+        assert hasattr(EcflowContext, "DESCRIPTION")
+
+        expected = "ecFlow suite definition"
+        actual = EcflowContext.DESCRIPTION
+        assert expected == actual
+
+    def test_getindex(self):
+        """Ensure that dict notation returns a sensible string."""
+        filename = '/path/to/foobar'
+
+        with patch("cleverdiff.contexts.EcflowContext._create_context",
+                   return_value=["/first", "/second", "/third"]):
+            with tempfile.NamedTemporaryFile(mode="wt", delete=False) as f:
+                filename = f.name
+                instance = EcflowContext(filename)
+
+                actual = instance[0]
+                expected = f"{filename}:/first"
+                assert expected == actual
+
+                actual = instance[2]
+                expected = f"{filename}:/third"
+                assert expected == actual
+
+    def test_create_context(self):
+        """Ensure that _create_context classmethod behaves as expected."""
+        content = textwrap.dedent("""
+            suite foo
+              limit BAZLIM 10
+              family bar
+                task bud
+                  trigger bar == complete
+                  edit SNOOZE 5
+                task baz
+                  inlimit BAZLIM
+                family goo
+                  task gunk
+                endfamily
+              endfamily
+              task end
+                trigger bar == complete
+            endsuite
+        """).splitlines(True)
+        expected = [
+            "",
+            "/foo",
+            "/foo",
+            "/foo/bar",
+            "/foo/bar/bud",
+            "/foo/bar/bud",
+            "/foo/bar/bud",
+            "/foo/bar/baz",
+            "/foo/bar/baz",
+            "/foo/bar/goo",
+            "/foo/bar/goo/gunk",
+            "/foo/bar/goo",
+            "/foo/bar",
+            "/foo/end",
+            "/foo/end",
+            "/foo",
+        ]
+        actual = EcflowContext._create_context(content)
+        assert expected == actual

--- a/cleverdiff/test_diffhunk.py
+++ b/cleverdiff/test_diffhunk.py
@@ -1,8 +1,9 @@
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
 
 import textwrap
 
 from cleverdiff.diffhunk import DiffHunk, Pair
+
 
 class Test_diffhunk(object):
     CONTEXT = Pair("file1", "file2")
@@ -11,10 +12,12 @@ class Test_diffhunk(object):
         mode = "insert"
         content = "+  I'm added"
         lines = Pair(34, 34)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             insert in file1:34 vs file2:34:
             +  I'm added
-        """)
+        """
+        )
         actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
         assert expected == actual
 
@@ -22,11 +25,13 @@ class Test_diffhunk(object):
         mode = "delete"
         content = "-    deleteme\n- and me!"
         lines = Pair(56, 55)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             delete in file1:56 vs file2:55:
             -    deleteme
             - and me!
-        """)
+        """
+        )
         actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
         assert expected == actual
 
@@ -34,11 +39,13 @@ class Test_diffhunk(object):
         mode = "change"
         content = "- line removed\n+ line inserted"
         lines = Pair(1, 2)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             change in file1:1 vs file2:2:
             - line removed
             + line inserted
-        """)
+        """
+        )
         actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
         assert expected == actual
 

--- a/cleverdiff/test_diffhunk.py
+++ b/cleverdiff/test_diffhunk.py
@@ -6,9 +6,9 @@ from cleverdiff.diffhunk import DiffHunk, Pair
 
 
 class Test_diffhunk(object):
-    CONTEXT = Pair("file1", "file2")
 
     def test_str_insert(self):
+        context = Pair("file1:34", "file2:34")
         mode = "insert"
         content = "+  I'm added"
         lines = Pair(34, 34)
@@ -18,10 +18,11 @@ class Test_diffhunk(object):
             +  I'm added
         """
         )
-        actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
+        actual = str(DiffHunk(mode, content, context, lines))
         assert expected == actual
 
     def test_str_delete(self):
+        context = Pair("file1:56", "file2:55")
         mode = "delete"
         content = "-    deleteme\n- and me!"
         lines = Pair(56, 55)
@@ -32,10 +33,11 @@ class Test_diffhunk(object):
             - and me!
         """
         )
-        actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
+        actual = str(DiffHunk(mode, content, context, lines))
         assert expected == actual
 
     def test_str_change(self):
+        context = Pair("file1:1", "file2:2")
         mode = "change"
         content = "- line removed\n+ line inserted"
         lines = Pair(1, 2)
@@ -46,7 +48,7 @@ class Test_diffhunk(object):
             + line inserted
         """
         )
-        actual = str(DiffHunk(mode, content, self.CONTEXT, lines))
+        actual = str(DiffHunk(mode, content, context, lines))
         assert expected == actual
 
 

--- a/cleverdiff/test_difflist.py
+++ b/cleverdiff/test_difflist.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, print_function)  # noqa
+from __future__ import absolute_import, division, print_function  # noqa
 
 import textwrap
 import difflib
@@ -13,17 +13,22 @@ from cleverdiff.difflist import DiffList
 
 class Test_DiffList__translate_diff_syntax(object):
     def test_insert_one(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     line2
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     insert
                     line2
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
 
         # unified diff hunk format:
         # @@ -start,count +start,count @@
@@ -31,154 +36,194 @@ class Test_DiffList__translate_diff_syntax(object):
         # count is omitted if 1
         # see https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified
         assert syntax == "@@ -1,0 +2 @@"
-        expected = ("insert", 1, 2)   # "i",start1,start2
+        expected = ("insert", 1, 2)  # "i",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_insert_many(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     line4
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     line2
                     line3
                     line4
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -1,0 +2,2 @@"
         expected = ("insert", 1, 2)
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_delete_one(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     deleteme
                     line2
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     line2
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2 +1,0 @@"
         expected = ("delete", 2, 1)  # "d",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_delete_many(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     deleteme
                     deletemetoo
                     line2
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     line2
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2,2 +1,0 @@"
         expected = ("delete", 2, 1)
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_change_one(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     oldline
                     line2
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     newline
                     line2
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2 +2 @@"
         expected = ("change", 2, 2)  # "c",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_change_many(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                     line1
                     oldline
                     alsooldline
                     line2
-                """).splitlines()
-        new = textwrap.dedent("""\
+                """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                     line1
                     newline
                     alsonewline
                     line2
-                """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2,2 +2,2 @@"
         expected = ("change", 2, 2)  # "c",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_change_and_insert(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                             line1
                             oldline
                             line2
-                        """).splitlines()
-        new = textwrap.dedent("""\
+                        """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                             line1
                             newline
                             instertme
                             line2
-                        """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                        """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2 +2,2 @@"
         expected = ("change", 2, 2)  # "c",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_change_and_delete(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                             line1
                             oldline
                             deleteme
                             line2
-                        """).splitlines()
-        new = textwrap.dedent("""\
+                        """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                             line1
                             newline
                             line2
-                        """).splitlines()
-        syntax, = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                   if i.startswith("@@")]
+                        """
+        ).splitlines()
+        syntax, = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ]
         assert syntax == "@@ -2,2 +2 @@"
         expected = ("change", 2, 2)  # "c",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
         assert actual == expected
 
     def test_change_and_insert_offset(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                             line1
                             oldline
                             line2
-                        """).splitlines()
-        new = textwrap.dedent("""\
+                        """
+        ).splitlines()
+        new = textwrap.dedent(
+            """\
                             line0
                             line1
                             newline
                             instertme
                             line2
-                        """).splitlines()
-        syntax = [i.strip() for i in difflib.unified_diff(ref, new, n=0)
-                  if i.startswith("@@")][1]
+                        """
+        ).splitlines()
+        syntax = [
+            i.strip() for i in difflib.unified_diff(ref, new, n=0) if i.startswith("@@")
+        ][1]
         assert syntax == "@@ -2 +3,2 @@"
         expected = ("change", 2, 3)  # "c",start1,start2
         actual = DiffList._translate_diff_syntax(syntax)
@@ -205,17 +250,21 @@ class Test_DiffList__translate_diff_syntax(object):
 
 class Test_DiffList_from_files(object):
     def test_from_files(self):
-        filetext1 = textwrap.dedent("""\
+        filetext1 = textwrap.dedent(
+            """\
                     suite foo
                       family bar
                         edit FOOBAR 5
                         task baz
                       endfamily
                     endsuite
-                  """)
+                  """
+        )
         filetext2 = filetext1.replace("baz", "boo")
-        expected = [d.context_to_string(no_labels=True)
-                    for d in DiffList(filetext1, filetext2)._diffs]
+        expected = [
+            d.context_to_string(no_labels=True)
+            for d in DiffList(filetext1, filetext2)._diffs
+        ]
 
         with tempfile.NamedTemporaryFile(mode="w+t", delete=False) as file1:
             file1.write(filetext1)
@@ -223,9 +272,10 @@ class Test_DiffList_from_files(object):
             with tempfile.NamedTemporaryFile(mode="w+t", delete=False) as file2:
                 file2.write(filetext2)
                 file2.seek(0)
-                actual = [d.context_to_string(no_labels=True)
-                          for d in DiffList.from_files(file1.name,
-                                                       file2.name)._diffs]
+                actual = [
+                    d.context_to_string(no_labels=True)
+                    for d in DiffList.from_files(file1.name, file2.name)._diffs
+                ]
 
         assert expected == actual
 
@@ -255,25 +305,29 @@ class Test_DiffList_from_files(object):
 
 class Test_DiffList__parse(object):
     def test_parse(self):
-        ref = textwrap.dedent("""\
+        ref = textwrap.dedent(
+            """\
                             line1
                             oldline
                             line2
                             deleteme
                             line3
                             line4
-                        """)
-        new = textwrap.dedent("""\
+                        """
+        )
+        new = textwrap.dedent(
+            """\
                             line1
                             newline
                             line2
                             line3
                             insertme
                             line4
-                        """)
-        input_lines = list(difflib.unified_diff(ref.splitlines(True),
-                                                new.splitlines(True),
-                                                n=0))
+                        """
+        )
+        input_lines = list(
+            difflib.unified_diff(ref.splitlines(True), new.splitlines(True), n=0)
+        )
         # ['--- \n',
         #  '+++ \n',
         #  '@@ -2 +2 @@\n',
@@ -285,17 +339,30 @@ class Test_DiffList__parse(object):
         #  '+insertme']
 
         difflist = DiffList(ref, new)
-        with patch("cleverdiff.difflist.DiffHunk") as diffhunk_patch, \
-             patch("cleverdiff.difflist.DiffHunk._translate_diff_syntax",
-                   return_value=[("change", 2, 2), ("delete", 4, 3),
-                                 ("insert", 5, 5)]) as trans_patch:
+        with patch("cleverdiff.difflist.DiffHunk") as diffhunk_patch, patch(
+            "cleverdiff.difflist.DiffHunk._translate_diff_syntax",
+            return_value=[("change", 2, 2), ("delete", 4, 3), ("insert", 5, 5)],
+        ) as trans_patch:
             difflist._parse(input_lines)
 
             expected_calls = [
-                call(mode="change", content="-oldline\n+newline\n", context=Pair(first="", second=""), lines=Pair(2,2)),
-                call(mode="delete", content="-deleteme\n", context=Pair(first="", second=""), lines=Pair(4, 3)),
-                call(mode="insert", content="+insertme\n", context=Pair(first="", second=""), lines=Pair(5, 5)),
+                call(
+                    mode="change",
+                    content="-oldline\n+newline\n",
+                    context=Pair(first="", second=""),
+                    lines=Pair(2, 2),
+                ),
+                call(
+                    mode="delete",
+                    content="-deleteme\n",
+                    context=Pair(first="", second=""),
+                    lines=Pair(4, 3),
+                ),
+                call(
+                    mode="insert",
+                    content="+insertme\n",
+                    context=Pair(first="", second=""),
+                    lines=Pair(5, 5),
+                ),
             ]
             assert expected_calls == diffhunk_patch.mock_calls
-
-

--- a/cleverdiff/test_difflist.py
+++ b/cleverdiff/test_difflist.py
@@ -349,19 +349,19 @@ class Test_DiffList__parse(object):
                 call(
                     mode="change",
                     content="-oldline\n+newline\n",
-                    context=Pair(first="", second=""),
+                    context=Pair(first=":2", second=":2"),
                     lines=Pair(2, 2),
                 ),
                 call(
                     mode="delete",
                     content="-deleteme\n",
-                    context=Pair(first="", second=""),
+                    context=Pair(first=":4", second=":3"),
                     lines=Pair(4, 3),
                 ),
                 call(
                     mode="insert",
                     content="+insertme\n",
-                    context=Pair(first="", second=""),
+                    context=Pair(first=":5", second=":5"),
                     lines=Pair(5, 5),
                 ),
             ]


### PR DESCRIPTION
Adds a mechanism for human-readable contexts. This is done by composing an instance of the `DiffList` class (via `context_cls` argument) with a type from the new `contexts` module. The correct type is selected from the filename extension via a lookup table in the `contexts` module. If no suitable extension mapping is found, or the extensions vary between the provided filenames, `DefaultContext` is used which just provides the filename and line number of each diff hunk.

This change also adds an ecFlow context in the `EcflowContext` type, which is automatically selected for the `.def` file extension. This translates line numbers into the relevant ecFlow node path at that line.

This completes #2 .