### PR TITLE
Pylint and pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - pip install pylint flake8
 script:
   - pytest
-  - pylint
-  - flake8
+  - pylint cleverdiff --disable=bad-continuation
+  - flake8 cleverdiff

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ python:
   - "3.7"
 
 script:
-  pytest
+  - pytest
+  - pylint
+  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install pylint flake8
+  - pip install isort black pyflakes
 script:
   - pytest
-  - pylint cleverdiff --disable=bad-continuation
-  - flake8 cleverdiff
+  - isort --check-only --recursive cleverdiff
+  - black --check cleverdiff
+  - pyflakes cleverdiff

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
   - "3.6"
   - "3.7"
-
+install:
+  - pip install pylint flake8
 script:
   - pytest
   - pylint

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install --user cleverdiff
 ## Usage
 Run the `cleverdiff.py` script, with each pair of files separated with `=` as arguments:
 ```
-python3 cleverdiff.py test_data/ref1.def=test_data/new1.def test_data/ref2.def=test_data/new2.def
+python3 cleverdiff.py test_data/ref.def=test_data/new.def test_data/ref2.def=test_data/new2.def
 ```
 
 *CleverDiff* will find the differences between each pair of files, then determine which are identical across all files, and give you a summary:
@@ -56,4 +56,4 @@ This difference is replicated elsewhere:
 ## Version history
 **v0.2**: Introduces ecFlow context (#2). Bug fixes.
 **v0.1.2**: Fixes failing tests. Adds Travis CI config.
-**v0.1**: initial version 
+**v0.1**: initial version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install --user cleverdiff
 ## Usage
 Run the `cleverdiff.py` script, with each pair of files separated with `=` as arguments:
 ```
-python3 cleverdiff.py test_data/ref.def=test_data/new.def test_data/ref2.def=test_data/new2.def
+python3 cleverdiff.py test_data/ref1.def=test_data/new1.def test_data/ref2.def=test_data/new2.def
 ```
 
 *CleverDiff* will find the differences between each pair of files, then determine which are identical across all files, and give you a summary:
@@ -56,4 +56,4 @@ This difference is replicated elsewhere:
 ## Version history
 **v0.2**: Introduces ecFlow context (#2). Bug fixes.
 **v0.1.2**: Fixes failing tests. Adds Travis CI config.
-**v0.1**: initial version
+**v0.1**: initial version 


### PR DESCRIPTION
Fixes #4

I have to add `--disable=bad-continuation` option to pylint since sometimes it conflicts with Black formatter.

And I'm not entirely sure about using flake8 instead stright and simple pycodestyle